### PR TITLE
feat: implement admin course veto and revocation (#9)

### DIFF
--- a/contracts/scholar_contracts/src/lib.rs
+++ b/contracts/scholar_contracts/src/lib.rs
@@ -22,6 +22,8 @@ pub enum DataKey {
     MinDeposit,
     Subscription(Address),
     HeartbeatInterval,
+    Admin,
+    VetoedCourse(Address, u64),
 }
 
 #[contracttype]
@@ -144,6 +146,12 @@ impl ScholarContract {
     }
 
     pub fn has_access(env: Env, student: Address, course_id: u64) -> bool {
+        // Check if course is vetoed for this student
+        let is_vetoed: bool = env.storage().instance().get(&DataKey::VetoedCourse(student.clone(), course_id)).unwrap_or(false);
+        if is_vetoed {
+            return false;
+        }
+        
         // Check subscription first
         if Self::has_active_subscription(env.clone(), student.clone(), course_id) {
             return true;
@@ -191,6 +199,53 @@ impl ScholarContract {
         };
         
         env.storage().instance().set(&DataKey::Subscription(subscriber.clone()), &subscription);
+    }
+
+    pub fn set_admin(env: Env, admin: Address) {
+        admin.require_auth();
+        
+        // Only allow setting admin if not already set
+        let existing_admin: Option<Address> = env.storage().instance().get(&DataKey::Admin);
+        if existing_admin.is_some() {
+            env.panic_with_error((soroban_sdk::xdr::ScErrorType::Contract, soroban_sdk::xdr::ScErrorCode::InvalidAction));
+        }
+        
+        env.storage().instance().set(&DataKey::Admin, &admin);
+    }
+
+    pub fn veto_course_access(env: Env, admin: Address, student: Address, course_id: u64) {
+        admin.require_auth();
+        
+        // Verify caller is admin
+        let stored_admin: Option<Address> = env.storage().instance().get(&DataKey::Admin);
+        if stored_admin.is_none() || stored_admin.unwrap() != admin {
+            env.panic_with_error((soroban_sdk::xdr::ScErrorType::Contract, soroban_sdk::xdr::ScErrorCode::InvalidAction));
+        }
+        
+        // Mark course as vetoed for this student
+        env.storage().instance().set(&DataKey::VetoedCourse(student.clone(), course_id), &true);
+        
+        // Revoke existing access by setting expiry to 0
+        let access_key = DataKey::Access(student.clone(), course_id);
+        if let Some(mut access) = env.storage().instance().get::<DataKey, Access>(&access_key) {
+            access.expiry_time = 0;
+            env.storage().instance().set(&access_key, &access);
+        }
+        
+        // Remove course from subscription if present
+        let sub_key = DataKey::Subscription(student.clone());
+        if let Some(mut subscription) = env.storage().instance().get::<DataKey, SubscriptionTier>(&sub_key) {
+            // Filter out the vetoed course
+            let mut new_course_ids = Vec::new(&env);
+            for i in 0..subscription.course_ids.len() {
+                let cid = subscription.course_ids.get(i).unwrap();
+                if cid != course_id {
+                    new_course_ids.push_back(cid);
+                }
+            }
+            subscription.course_ids = new_course_ids;
+            env.storage().instance().set(&sub_key, &subscription);
+        }
     }
 }
 

--- a/contracts/scholar_contracts/src/test.rs
+++ b/contracts/scholar_contracts/src/test.rs
@@ -143,3 +143,40 @@ fn test_minimum_deposit() {
     );
     assert!(result.is_err());
 }
+
+#[test]
+fn test_admin_veto() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let student = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+
+    let token_address = env.register_stellar_asset_contract_v2(token_admin.clone());
+    let token_client = token::StellarAssetClient::new(&env, &token_address.address());
+    token_client.mint(&student, &2000);
+
+    let contract_id = env.register(ScholarContract, ());
+    let client = ScholarContractClient::new(&env, &contract_id);
+    
+    client.init(&10, &3600, &10, &100, &60);
+    client.set_admin(&admin);
+
+    // 1. Test veto on bought access
+    client.buy_access(&student, &1, &200, &token_address.address());
+    assert!(client.has_access(&student, &1));
+
+    client.veto_course_access(&admin, &student, &1);
+    assert!(!client.has_access(&student, &1));
+
+    // 2. Test veto on subscription access
+    let course_ids = vec![&env, 2, 3];
+    client.buy_subscription(&student, &course_ids, &1, &500, &token_address.address());
+    assert!(client.has_access(&student, &2));
+    assert!(client.has_access(&student, &3));
+
+    client.veto_course_access(&admin, &student, &2);
+    assert!(!client.has_access(&student, &2));
+    assert!(client.has_access(&student, &3)); // Other course in sub should still work
+}


### PR DESCRIPTION
This PR implements the Admin Veto functionality to satisfy requirement #9.

**Features:**
- [x] Initial contract administrator setup via [set_admin](cci:1://file:///C:/Users/HP/Desktop/wv3/issue-9/contracts/scholar_contracts/src/lib.rs:203:4-213:5).
- [x] Admin can veto specific courses for specific students.
- [x] Vetoing automatically revokes existing purchased access and filters courses from active subscriptions.
- [x] [has_access](cci:1://file:///C:/Users/HP/Desktop/wv3/issue-9/contracts/scholar_contracts/src/lib.rs:147:4-170:5) now includes a mandatory check against the vetoed state.

**Tests:**
- [x] Added [test_admin_veto](cci:1://file:///C:/Users/HP/Desktop/wv3/issue-9/contracts/scholar_contracts/src/test.rs:146:0-181:1) to verify all revocation paths.

Closes #9
