### PR TITLE
Global Course Veto and Platform Governance (#19)

### DIFF
--- a/contracts/scholar_contracts/src/lib.rs
+++ b/contracts/scholar_contracts/src/lib.rs
@@ -33,6 +33,7 @@ pub enum DataKey {
     VetoedCourse(Address, u64),
     IsTeacher(Address),
     Scholarship(Address), // student -> Scholarship struct
+    VetoedCourseGlobal(u64),
 }
 
 #[contracttype]
@@ -155,6 +156,12 @@ impl ScholarContract {
     }
 
     pub fn has_access(env: Env, student: Address, course_id: u64) -> bool {
+        // Check if course is globally vetoed
+        let is_globally_vetoed: bool = env.storage().instance().get(&DataKey::VetoedCourseGlobal(course_id)).unwrap_or(false);
+        if is_globally_vetoed {
+            return false;
+        }
+
         // Check if course is vetoed for this student
         let is_vetoed: bool = env.storage().instance().get(&DataKey::VetoedCourse(student.clone(), course_id)).unwrap_or(false);
         if is_vetoed {
@@ -274,6 +281,18 @@ impl ScholarContract {
         // Transfer to teacher
         let client = token::Client::new(&env, &scholarship.token);
         client.transfer(&env.current_contract_address(), &teacher, &amount);
+    }
+
+    pub fn veto_course_globally(env: Env, admin: Address, course_id: u64, status: bool) {
+        admin.require_auth();
+        
+        // Verify caller is admin
+        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).expect("Admin not set");
+        if stored_admin != admin {
+            env.panic_with_error((soroban_sdk::xdr::ScErrorType::Contract, soroban_sdk::xdr::ScErrorCode::InvalidAction));
+        }
+        
+        env.storage().instance().set(&DataKey::VetoedCourseGlobal(course_id), &status);
     }
 
     pub fn veto_course_access(env: Env, admin: Address, student: Address, course_id: u64) {

--- a/contracts/scholar_contracts/src/test.rs
+++ b/contracts/scholar_contracts/src/test.rs
@@ -228,3 +228,45 @@ fn test_scholarship_role() {
     );
     assert!(result.is_err());
 }
+
+#[test]
+fn test_global_course_veto() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let student_a = Address::generate(&env);
+    let student_b = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+
+    let token_address = env.register_stellar_asset_contract_v2(token_admin.clone());
+    let token_client = token::StellarAssetClient::new(&env, &token_address.address());
+    token_client.mint(&student_a, &1000);
+    token_client.mint(&student_b, &1000);
+
+    let contract_id = env.register(ScholarContract, ());
+    let client = ScholarContractClient::new(&env, &contract_id);
+    
+    client.init(&10, &3600, &10, &100, &60);
+    client.set_admin(&admin);
+
+    // 1. Give both students access to course 1
+    client.buy_access(&student_a, &1, &200, &token_address.address());
+    let course_ids = vec![&env, 1];
+    client.buy_subscription(&student_b, &course_ids, &1, &300, &token_address.address());
+
+    assert!(client.has_access(&student_a, &1));
+    assert!(client.has_access(&student_b, &1));
+
+    // 2. Admin vetoes course 1 GLOBALLY
+    client.veto_course_globally(&admin, &1, &true);
+
+    // 3. Both should lose access
+    assert!(!client.has_access(&student_a, &1));
+    assert!(!client.has_access(&student_b, &1));
+
+    // 4. Verification that other courses are not affected
+    let course_ids_2 = vec![&env, 2];
+    client.buy_subscription(&student_b, &course_ids_2, &1, &300, &token_address.address());
+    assert!(client.has_access(&student_b, &2));
+}


### PR DESCRIPTION
This PR implements global course revocation as defined in issue #19.

**Changes:**
- [x] Admin-only global course veto mechanism.
- [x] [has_access](cci:1://file:///C:/Users/HP/Desktop/wv3/issue-10/contracts/scholar_contracts/src/lib.rs:156:4-179:5) updated to prioritize global safety blocks.
- [x] Built on top of scholarship and per-student veto features.

**Tests:**
- [x] Verified that global veto blocks access for all students regardless of their access tier.
- [x] Verified that global veto does not impact access to other courses.

Closes #19
